### PR TITLE
adding cadence workflow domain

### DIFF
--- a/src/.vuepress/CNAME
+++ b/src/.vuepress/CNAME
@@ -1,0 +1,1 @@
+cadenceworkflow.io


### PR DESCRIPTION
This PR is to add a domain to push built assets to.
Once `gh-pages` branch is enabled for github pages deploy, it will automatically publish to http://cadenceworkflow.io