### PR TITLE
Configure custom domain for cadence docs

### DIFF
--- a/.github/workflows/publish-to-gh-pages.yml
+++ b/.github/workflows/publish-to-gh-pages.yml
@@ -19,9 +19,9 @@ jobs:
 
       - name: Configure custom domain
         uses: finnp/create-file-action@1.0.0
-          env:
-            FILE_NAME: "dist/CNAME"
-            FILE_DATA: "hello world"
+        with:
+          FILE_NAME: "dist/CNAME"
+          FILE_DATA: "hello world"
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1

--- a/.github/workflows/publish-to-gh-pages.yml
+++ b/.github/workflows/publish-to-gh-pages.yml
@@ -21,7 +21,7 @@ jobs:
         uses: finnp/create-file-action@1.0.0
         env:
           FILE_NAME: "dist/CNAME"
-          FILE_DATA: "hello world"
+          FILE_DATA: ${{ secrets.CUSTOM_DOMAIN }}
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1

--- a/.github/workflows/publish-to-gh-pages.yml
+++ b/.github/workflows/publish-to-gh-pages.yml
@@ -20,8 +20,9 @@ jobs:
       - name: Configure custom domain
         uses: finnp/create-file-action@1.0.0
         with:
-          FILE_NAME: "dist/CNAME"
-          FILE_DATA: "hello world"
+          args:
+            FILE_NAME: "dist/CNAME"
+            FILE_DATA: "hello world"
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1

--- a/.github/workflows/publish-to-gh-pages.yml
+++ b/.github/workflows/publish-to-gh-pages.yml
@@ -17,7 +17,7 @@ jobs:
           npm install
           npm run build
 
-      - name: Configure custom domain
+      - name: Configure domain
         uses: finnp/create-file-action@1.0.0
         env:
           FILE_NAME: "dist/CNAME"

--- a/.github/workflows/publish-to-gh-pages.yml
+++ b/.github/workflows/publish-to-gh-pages.yml
@@ -19,10 +19,9 @@ jobs:
 
       - name: Configure custom domain
         uses: finnp/create-file-action@1.0.0
-        with:
-          args:
-            FILE_NAME: "dist/CNAME"
-            FILE_DATA: "hello world"
+        env:
+          FILE_NAME: "dist/CNAME"
+          FILE_DATA: "hello world"
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1

--- a/.github/workflows/publish-to-gh-pages.yml
+++ b/.github/workflows/publish-to-gh-pages.yml
@@ -18,7 +18,7 @@ jobs:
           npm run build
 
       - name: Configure custom domain
-        uses: "finnp/create-file-action@1.0.0"
+        uses: "finnp/create-file-action@master"
           env:
             FILE_NAME: "dist/CNAME"
             FILE_DATA: "hello world"

--- a/.github/workflows/publish-to-gh-pages.yml
+++ b/.github/workflows/publish-to-gh-pages.yml
@@ -18,7 +18,7 @@ jobs:
           npm run build
 
       - name: Configure custom domain
-        uses: "finnp/create-file-action@master"
+        uses: finnp/create-file-action@1.0.0
           env:
             FILE_NAME: "dist/CNAME"
             FILE_DATA: "hello world"

--- a/.github/workflows/publish-to-gh-pages.yml
+++ b/.github/workflows/publish-to-gh-pages.yml
@@ -30,4 +30,3 @@ jobs:
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: dist # The folder the action should deploy.
           CLEAN: true # Automatically remove deleted files from the deploy branch
-

--- a/.github/workflows/publish-to-gh-pages.yml
+++ b/.github/workflows/publish-to-gh-pages.yml
@@ -17,6 +17,12 @@ jobs:
           npm install
           npm run build
 
+      - name: Configure custom domain
+        uses: "finnp/create-file-action@1.0.0"
+          env:
+            FILE_NAME: "dist/CNAME"
+            FILE_DATA: "hello world"
+
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:

--- a/.github/workflows/publish-to-gh-pages.yml
+++ b/.github/workflows/publish-to-gh-pages.yml
@@ -30,3 +30,4 @@ jobs:
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: dist # The folder the action should deploy.
           CLEAN: true # Automatically remove deleted files from the deploy branch
+

--- a/package.json
+++ b/package.json
@@ -5,8 +5,6 @@
   "license": "MIT",
   "scripts": {
     "build": "vuepress build src",
-    "postbuild": "npm run copy-cname",
-    "copy-cname": "cp src/.vuepress/CNAME ./dist",
     "start": "vuepress dev src"
   },
   "dependencies": {

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -1,6 +1,5 @@
 const { slackUrl } = require('./constants');
 
-
 module.exports = {
   dest: 'dist',
   lang: 'en-US',

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -2,7 +2,6 @@ const { slackUrl } = require('./constants');
 
 
 module.exports = {
-  base: '/cadence-docs/',
   dest: 'dist',
   lang: 'en-US',
   title: 'Cadence',

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -1,5 +1,6 @@
 const { slackUrl } = require('./constants');
 
+
 module.exports = {
   base: '/cadence-docs/',
   dest: 'dist',

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -1,6 +1,7 @@
 const { slackUrl } = require('./constants');
 
 module.exports = {
+  base: '/cadence-docs/',
   dest: 'dist',
   lang: 'en-US',
   title: 'Cadence',


### PR DESCRIPTION
Add an optional secret `CUSTOM_DOMAIN` which allows a user to set the domain for where to deploy cadence docs. If secret is not set it will create an empty file which does nothing.

The idea of setting this information in a secret is so that if the project is forked, users don't accidentally publish CNAME. 

However it does allow a user to publish their fork to their own domain if they want to.

Removed old way of publishing CNAME.