### PR TITLE
Link to cadence docs in navigation bar

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -68,6 +68,7 @@ module.exports = {
           { text: 'Cadence Java Client', link: 'https://github.com/uber-java/cadence-client' },
           { text: 'Cadence Java Client Samples', link: 'https://github.com/uber/cadence-java-samples' },
           { text: 'Cadence Web UI', link: 'https://github.com/uber/cadence-web' },
+          { text: 'Cadence Docs', link: 'https://github.com/uber/cadence-docs' },
         ],
       },
       {


### PR DESCRIPTION
Created a link under github dropdown to navigate to github cadence docs page.

### Screenshot
<img width="1664" alt="Screen Shot 2020-11-09 at 9 49 54 AM" src="https://user-images.githubusercontent.com/58960161/98577674-24dc5380-2271-11eb-9d76-069bd85dc4c7.png">
