### PR TITLE
Feature/automate cypress nightly

### DIFF
--- a/.github/workflows/nightly-integration-test.yml
+++ b/.github/workflows/nightly-integration-test.yml
@@ -2,8 +2,7 @@ name: Nightly integration test
 on:
   schedule:
     # Run every day at 0 minutes and 0 hours (midnight GMT)
-    # - cron: '0 0 * * *'
-    - cron: '* * * * *'
+    - cron: '0 0 * * *'
 jobs:
   nightly-integration-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-integration-test.yml
+++ b/.github/workflows/nightly-integration-test.yml
@@ -1,0 +1,15 @@
+name: Nightly integration test
+on:
+  schedule:
+    # Run every day at 0 minutes and 0 hours (midnight GMT)
+    # - cron: '0 0 * * *'
+    - cron: '* * * * *'
+jobs:
+  nightly-integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: cypress-io/github-action@v2
+        with:
+          browser: chrome
+          headless: true


### PR DESCRIPTION
Adding cron github action which will run nightly at midnight GMT.
This cron job will run the integration test to check if slack short link is working.