### PR TITLE
Fix wrong name

### DIFF
--- a/src/docs/00-get-started/01-server-installation.md
+++ b/src/docs/00-get-started/01-server-installation.md
@@ -68,7 +68,7 @@ Domain test-domain successfully registered.
 ```
 Check that the domain is indeed registered:
 ```bash
-> docker run --network=host --rm ubercadence/cli:master --do samples-domain domain describe
+> docker run --network=host --rm ubercadence/cli:master --do test-domain domain describe
 Name: test-domain
 Description:
 OwnerEmail:


### PR DESCRIPTION
docker run --network=host --rm ubercadence/cli:master --do test-domain domain register -rd 1

docker run --network=host --rm ubercadence/cli:master --do sample-domain domain describe

Example names are inconsistent