### PR TITLE
Fix/broken markdown

### DIFF
--- a/src/docs/00-get-started/01-server-installation.md
+++ b/src/docs/00-get-started/01-server-installation.md
@@ -87,5 +87,5 @@ Bad binaries to reset:
 >
 ```
 
-# What's Next
+## What's Next
 Go to [Java HelloWorld](/docs/get-started/java-hello-world) or [Golang HelloWorld](/docs/get-started/golang-hello-world).

--- a/src/docs/00-get-started/02-java-hello-world.md
+++ b/src/docs/00-get-started/02-java-hello-world.md
@@ -165,5 +165,5 @@ Now let's look at the :workflow_execution: history:
 ```
 Even for such a trivial :workflow:, the history gives a lot of useful information. For complex :workflow:workflows: this is a really useful tool for production and development troubleshooting. History can be automatically archived to a long-term blob store (for example Amazon S3) upon :workflow: completion for compliance, analytical, and troubleshooting purposes.
 
-# What is Next 
+## What is Next
 Now you have completed the tutorials. You can continue to explore the key [concepts](/docs/concepts) in Cadence, and also how to use them with [Java Client](/docs/java-client)

--- a/src/docs/00-get-started/03-golang-hello-world.md
+++ b/src/docs/00-get-started/03-golang-hello-world.md
@@ -81,5 +81,5 @@ And start a workflow:
 ./bin/helloworld
 ```
 
-# What is Next
+## What is Next
 Now you have completed the tutorials. You can continue to explore the key [concepts](/docs/concepts) in Cadence, and also how to use them with [Go Client](/docs/go-client)

--- a/src/docs/00-get-started/04-video-tutorials.md
+++ b/src/docs/00-get-started/04-video-tutorials.md
@@ -17,7 +17,7 @@ An Introduction to the Cadence programming model and value proposition.
 </figure>
 
 
-# HelloWorld
+## HelloWorld
 A step-by-step video tutorial about how to install and run HellowWorld(Java).
 <figure class="video-container">
   <iframe

--- a/src/docs/00-get-started/index.md
+++ b/src/docs/00-get-started/index.md
@@ -29,7 +29,7 @@ that are shared by hundreds of applications. See service [topology](/docs/concep
 image for the Cadence server is available on Docker Hub at
 [ubercadence/server](https://hub.docker.com/r/ubercadence/server).
 
-# What's Next
+## What's Next
 Let's try with some sample workflows.
 To start with, go to [server installation](/docs/get-started/installation) to install cadence locally, and run a HelloWorld sample with [Java](/docs/get-started/java-hello-world) or [Golang](/docs/get-started/golang-hello-world).
 

--- a/src/docs/04-java-client/11-queries.md
+++ b/src/docs/04-java-client/11-queries.md
@@ -109,7 +109,7 @@ cadence: docker run --network=host --rm ubercadence/cli:master --do test-domain 
 The :query:Query: method can accept parameters. This might be useful if only part of the :workflow: state should be returned.
 
 ## Run Query from external application code
-The [WorkflowStub](https://www.javadoc.io/static/com.uber.cadence/cadence-client/2.7.9-alpha/com/uber/cadence/client/WorkflowClient.html#newWorkflowStub-java.lang.Class-java.lang.String-) without WorkflowOptions is for signal or [query](/docs/java-client/queries
+The [WorkflowStub](https://www.javadoc.io/static/com.uber.cadence/cadence-client/2.7.9-alpha/com/uber/cadence/client/WorkflowClient.html#newWorkflowStub-java.lang.Class-java.lang.String-) without WorkflowOptions is for signal or [query](/docs/java-client/queries)
 
 
 ## Consistent Query

--- a/src/docs/04-java-client/16-side-effect.md
+++ b/src/docs/04-java-client/16-side-effect.md
@@ -4,7 +4,7 @@ title: Side Effect
 permalink: /docs/java-client/side-effect
 ---
 
-## Side Effect
+# Side Effect
 
 Side Effect allow workflow executes the provided function once, records its result into the workflow history.
 The recorded result on history will be returned without executing the provided function during replay. This

--- a/src/docs/04-java-client/17-testing.md
+++ b/src/docs/04-java-client/17-testing.md
@@ -4,7 +4,7 @@ title: Testing
 permalink: /docs/java-client/testing
 ---
 
-## Activity Test Environment
+# Activity Test Environment
 
 [TestActivityEnvironment](https://www.javadoc.io/static/com.uber.cadence/cadence-client/2.7.9-alpha/com/uber/cadence/testing/TestActivityEnvironment.html) is the helper class for unit testing activity implementations. Supports calls to Activity methods from the tested activities. An example test:
 

--- a/src/docs/05-go-client/index.md
+++ b/src/docs/05-go-client/index.md
@@ -14,7 +14,7 @@ Cadence requires determinism of the :workflow: code. It supports deterministic e
 
 For example, instead of native Go channels, :workflow: code must use the `workflow.Channel` interface. Instead of `select`, the `workflow.Selector` interface must be used.
 
-For more information, see [Creating Workflows](02-create-workflows/).
+For more information, see [Creating Workflows](create-workflows/).
 
 ## Links
 


### PR DESCRIPTION
Things fixed:
1. Markdown should contain one h1 (or single #) tag in a document.
2. Some markdown documents only contain h2 (no h1), changed first h2 to a h1.
3. Broken links
4. Updated link which was not referencing a permalink