### PR TITLE
Add missing Prometheus config

### DIFF
--- a/src/docs/01-get-started/01-server-installation.md
+++ b/src/docs/01-get-started/01-server-installation.md
@@ -14,7 +14,7 @@ Follow the Docker installation instructions found here: [https://docs.docker.com
 
 Download the Cadence docker-compose file:
 ```bash
-> curl -O https://raw.githubusercontent.com/uber/cadence/master/docker/docker-compose.yml
+> curl -O https://raw.githubusercontent.com/uber/cadence/master/docker/docker-compose.yml && curl -O https://raw.githubusercontent.com/uber/cadence/master/docker/prometheus_config.yml
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100   675  100   675    0     0    958      0 --:--:-- --:--:-- --:--:--   958


### PR DESCRIPTION
It appears that `prometheus_config.yml` is required now (I believe https://github.com/uber/cadence/commit/a86abb4825db23200c593c5f2637e256f2d083ab to be the culprit of this requirement). 