### PR TITLE
Fix create workflows link on go-client intro page

### DIFF
--- a/src/docs/05-go-client/index.md
+++ b/src/docs/05-go-client/index.md
@@ -14,7 +14,7 @@ Cadence requires determinism of the :workflow: code. It supports deterministic e
 
 For example, instead of native Go channels, :workflow: code must use the `workflow.Channel` interface. Instead of `select`, the `workflow.Selector` interface must be used.
 
-For more information, see [Creating Workflows](create-workflows/).
+For more information, see [Creating Workflows](/docs/go-client/create-workflows).
 
 ## Links
 


### PR DESCRIPTION
Create workflows link on [go-client intro page](https://cadenceworkflow.io/docs/go-client/#overview) is broken. It links to the page https://cadenceworkflow.io/docs/05-go-client/create-workflows/ which is incorrect and does not exist.