### PR TITLE
Make samples more prominent in getting started section

### DIFF
--- a/src/docs/01-get-started/02-java-hello-world.md
+++ b/src/docs/01-get-started/02-java-hello-world.md
@@ -9,7 +9,7 @@ This section provides step by step instructions on how to write and run a HelloW
 
 For complete, ready to build samples covering all the key Cadence concepts go to [Cadence-Java-Samples](https://github.com/uber/cadence-java-samples).
 
-You can also review[Java-Client](/docs/java-client) and [java-docs](https://www.javadoc.io/doc/com.uber.cadence/cadence-client/latest/index.html) for more documentation.
+You can also review [Java-Client](/docs/java-client) and [java-docs](https://www.javadoc.io/doc/com.uber.cadence/cadence-client/latest/index.html) for more documentation.
 
 
 ## Include Cadence Java Client Dependency

--- a/src/docs/01-get-started/02-java-hello-world.md
+++ b/src/docs/01-get-started/02-java-hello-world.md
@@ -5,7 +5,11 @@ permalink: /docs/get-started/java-hello-world
 ---
 
 # Java Hello World
-This section only describe how to write and run a HelloWorld with Java. Go to [Cadence-Java-Samples](https://github.com/uber/cadence-java-samples) for more examples, and [Java-Client](/docs/java-client) and [java-docs](https://www.javadoc.io/doc/com.uber.cadence/cadence-client/latest/index.html) for more documentation.
+This section provides step by step instructions on how to write and run a HelloWorld with Java. 
+
+For complete, ready to build samples covering all the key Cadence concepts go to [Cadence-Java-Samples](https://github.com/uber/cadence-java-samples).
+
+You can also review[Java-Client](/docs/java-client) and [java-docs](https://www.javadoc.io/doc/com.uber.cadence/cadence-client/latest/index.html) for more documentation.
 
 
 ## Include Cadence Java Client Dependency

--- a/src/docs/01-get-started/03-golang-hello-world.md
+++ b/src/docs/01-get-started/03-golang-hello-world.md
@@ -5,7 +5,11 @@ permalink: /docs/get-started/golang-hello-world
 ---
 
 # Golang Hello World
-This section only describe how to write and run a HelloWorld with Golang. Go to [Cadence-Samples](https://github.com/uber-common/cadence-samples) for more examples, and [Cadence-Client](https://github.com/uber-go/cadence-client/) and [go-docs](https://pkg.go.dev/go.uber.org/cadence) for more documentation.
+This section provides step by step instructions on how to write and run a HelloWorld with Golang. 
+
+For complete, ready to build samples covering all the key Cadence concepts go to [Cadence-Samples](https://github.com/uber-common/cadence-samples) for more examples.
+
+You can also review [Cadence-Client](https://github.com/uber-go/cadence-client/) and [go-docs](https://pkg.go.dev/go.uber.org/cadence) for more documentation.
 
 ## Include Golang cadence-client dependency
 


### PR DESCRIPTION
I spent some time working on the example here before working out that the sample repo was a much easier place to get started. Suggest this update to send users more directly to the sample repo if they just want to build and run something.