### PR TITLE
Added Example for Polling External Services in Cadence Polling use cases section

### DIFF
--- a/src/docs/02-use-cases/03-polling.md
+++ b/src/docs/02-use-cases/03-polling.md
@@ -14,4 +14,4 @@ Some real-world use cases:
 
 * Network, host and service monitoring
 * Processing files uploaded to FTP or S3
-* Polling an external API for a specific resource to become available
+* [Cadence Polling Cookbook by Instaclustr: Polling an external API for a specific resource to become available: ](https://info.instaclustr.com/rs/620-JHM-287/images/Cadence_Cookbook.pdf)


### PR DESCRIPTION
Updated Polling Use Cases to include a link to a Cadence Polling Cookbook  that includes a detailed example for polling external services