### PR TITLE
Add gRPC with TLS examples for Java and Go Clients

### DIFF
--- a/src/docs/04-java-client/04-starting-workflow-executions.md
+++ b/src/docs/04-java-client/04-starting-workflow-executions.md
@@ -6,8 +6,12 @@ permalink: /docs/java-client/starting-workflow-executions
 
 # Starting workflow executions
 
+## Creating a WorkflowClient
+
 A :workflow: interface that executes a :workflow: requires initializing a `WorkflowClient` instance, creating
 a client side stub to the :workflow:, and then calling a method annotated with @WorkflowMethod.
+
+A simple `WorkflowClient` instance that utilises the :tchannel: communication protocol can be initialised as follows:
 
 ```java
 WorkflowClient workflowClient =
@@ -19,12 +23,47 @@ WorkflowClient workflowClient =
 FileProcessingWorkflow workflow = workflowClient.newWorkflowStub(FileProcessingWorkflow.class);
 ```
 
-If you are using version prior to 3.0.0
+Alternatively, if wishing to create a `WorkflowClient` that uses TLS, we can initialise a client that uses the gRPC communication protocol instead. First, additions will need to be made to the project's *pom.xml*:
+
+    <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-netty</artifactId>
+        <version>LATEST.RELEASE.VERSION</version>
+    </dependency>
+    <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-all</artifactId>
+        <version>LATEST.RELEASE.VERSION</version>
+    </dependency>
+
+Then, use the following client implementation; provide a TLS certificate with which the cluster has also been configured (replace `"/path/to/cert/file"` in the sample):
+
+```java
+WorkflowClient workflowClient =
+        WorkflowClient.newInstance(
+            new Thrift2ProtoAdapter(
+                IGrpcServiceStubs.newInstance(
+                    ClientOptions.newBuilder().setGRPCChannel(
+                        NettyChannelBuilder.forAddress(cadenceServiceHost, cadenceServicePort)
+                            .useTransportSecurity()
+                            .defaultLoadBalancingPolicy("round_robin")
+                            .sslContext(GrpcSslContexts.forClient()
+                                .trustManager(new File("/path/to/cert/file"))
+                                .build()).build()).build())),
+            WorkflowClientOptions.newBuilder().setDomain(domain).build());
+// Create a workflow stub.
+FileProcessingWorkflow workflow = workflowClient.newWorkflowStub(FileProcessingWorkflow.class);
+```
+
+Or, if you are using version prior to 3.0.0, a `WorkflowClient` can be created as follows:
+
 ```java
 WorkflowClient workflowClient = WorkflowClient.newClient(cadenceServiceHost, cadenceServicePort, domain);
 // Create a workflow stub.
 FileProcessingWorkflow workflow = workflowClient.newWorkflowStub(FileProcessingWorkflow.class);
 ```
+
+## Executing Workflows
 
 There are two ways to start :workflow_execution:: asynchronously and synchronously. Asynchronous start initiates a :workflow_execution: and immediately returns to the caller. This is the most common way to start :workflow:workflows: in production code. Synchronous invocation starts a :workflow:
 and then waits for its completion. If the process that started the :workflow: crashes or stops waiting, the :workflow: continues executing.

--- a/src/docs/05-go-client/01-workers.md
+++ b/src/docs/05-go-client/01-workers.md
@@ -219,5 +219,3 @@ func buildCadenceClient() workflowserviceclient.Interface {
      )
 }
 ```
-
-

--- a/src/docs/05-go-client/01-workers.md
+++ b/src/docs/05-go-client/01-workers.md
@@ -10,6 +10,8 @@ A :worker: or *:worker: service* is a service that hosts the :workflow: and :act
 
 You can run a Cadence :worker: in a new or an existing service. Use the framework APIs to start the Cadence :worker: and link in all :activity: and :workflow: implementations that you require the service to execute.
 
+The following is an example worker service utilising tchannel, one of the two transport protocols supported by Cadence.
+
 ```go
 package main
 
@@ -89,3 +91,133 @@ func startWorker(logger *zap.Logger, service workflowserviceclient.Interface) {
     logger.Info("Started Worker.", zap.String("worker", TaskListName))
 }
 ```
+
+The other supported transport protocol is gRPC. A worker service using gRPC can be set up in similar fashion, but the `buildCadenceClient` function will need the following alterations, and some of the imported packages need to change.
+
+```go
+
+import (
+
+    "go.uber.org/cadence/.gen/go/cadence"
+    "go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
+    "go.uber.org/cadence/compatibility"
+    "go.uber.org/cadence/worker"
+
+    apiv1 "github.com/uber/cadence-idl/go/proto/api/v1"
+    "github.com/uber-go/tally"
+    "go.uber.org/zap"
+    "go.uber.org/zap/zapcore"
+    "go.uber.org/yarpc"
+    "go.uber.org/yarpc/transport/grpc"
+)
+
+.
+.
+.
+
+func buildCadenceClient() workflowserviceclient.Interface {
+
+    dispatcher := yarpc.NewDispatcher(yarpc.Config{
+      Name: ClientName,
+      Outbounds: yarpc.Outbounds{
+        CadenceService: {Unary: grpc.NewTransport().NewSingleOutbound(HostPort)},
+      },
+    })
+    if err := dispatcher.Start(); err != nil {
+      panic("Failed to start dispatcher")
+    }
+
+    clientConfig := dispatcher.ClientConfig(CadenceService)
+
+    return compatibility.NewThrift2ProtoAdapter(
+      apiv1.NewDomainAPIYARPCClient(clientConfig),
+      apiv1.NewWorkflowAPIYARPCClient(clientConfig),
+      apiv1.NewWorkerAPIYARPCClient(clientConfig),
+      apiv1.NewVisibilityAPIYARPCClient(clientConfig),
+    )
+}
+```
+
+Note also that the `HostPort` variable must be changed to target the gRPC listener port of the Cadence cluster (typically, 7833).
+
+Finally, gRPC can also support TLS connections between Go clients and the Cadence server. This requires the following alterations to the imported packages, and the `buildCadenceClient` function. Note that this also requires you replace `"path/to/cert/file"` in the function with a path to a valid certificate file matching the TLS configuration of the Cadence server.
+
+```go
+
+import (
+
+    "fmt"
+
+    "go.uber.org/cadence/.gen/go/cadence"
+    "go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
+    "go.uber.org/cadence/compatibility"
+    "go.uber.org/cadence/worker"
+
+    apiv1 "github.com/uber/cadence-idl/go/proto/api/v1"
+    "github.com/uber-go/tally"
+    "go.uber.org/zap"
+    "go.uber.org/zap/zapcore"
+    "go.uber.org/yarpc"
+    "go.uber.org/yarpc/transport/grpc"
+    "go.uber.org/yarpc/peer"
+    "go.uber.org/yarpc/peer/hostport"
+
+    "crypto/tls"
+    "crypto/x509"
+    "io/ioutil"
+
+    "google.golang.org/grpc/credentials"
+)
+
+.
+.
+.
+
+func buildCadenceClient() workflowserviceclient.Interface {
+     grpcTransport := grpc.NewTransport()
+     var dialOptions []grpc.DialOption
+ 
+     caCert, err := ioutil.ReadFile("/path/to/cert/file")
+     if err != nil {
+          fmt.Printf("Failed to load server CA certificate: %v", zap.Error(err))
+     }
+ 
+     caCertPool := x509.NewCertPool()
+     if !caCertPool.AppendCertsFromPEM(caCert) {
+          fmt.Errorf("Failed to add server CA's certificate")
+     }
+ 
+     tlsConfig := tls.Config{
+          RootCAs: caCertPool,
+     }
+ 
+     creds := credentials.NewTLS(&tlsConfig)
+     dialOptions = append(dialOptions, grpc.DialerCredentials(creds))
+ 
+     dialer := grpcTransport.NewDialer(dialOptions...)
+     outbound := grpcTransport.NewOutbound(
+                        peer.NewSingle(hostport.PeerIdentifier(HostPort), dialer)
+                 )
+ 
+     dispatcher := yarpc.NewDispatcher(yarpc.Config{
+          Name: ClientName,
+          Outbounds: yarpc.Outbounds{
+               CadenceService: {Unary: outbound},
+          },
+     })
+     if err := dispatcher.Start(); err != nil {
+          panic("Failed to start dispatcher")
+     }
+ 
+     clientConfig := dispatcher.ClientConfig(CadenceService)
+ 
+     return compatibility.NewThrift2ProtoAdapter(
+          apiv1.NewDomainAPIYARPCClient(clientConfig),
+          apiv1.NewWorkflowAPIYARPCClient(clientConfig),
+          apiv1.NewWorkerAPIYARPCClient(clientConfig),
+          apiv1.NewVisibilityAPIYARPCClient(clientConfig),
+     )
+}
+```
+
+


### PR DESCRIPTION
Currently, the Java and Go Client SDKs do not offer initialisation examples for creating TLS-enabled clients.

We've added an example for each in the appropriate pages, as well as a plain (non-TLS) gRPC example for the Go SDK. 

We've also made some basic edits done some formatting on the surrounding text just to integrate the examples in the documentation flow.