### PR TITLE
Adding more advanced example of the scheduling cadence clients support.

### DIFF
--- a/src/docs/04-java-client/08-distributed-cron.md
+++ b/src/docs/04-java-client/08-distributed-cron.md
@@ -16,7 +16,8 @@ You can also start a :workflow: using the Cadence :CLI: with an optional cron sc
 For :workflow:workflows: with CronSchedule:
 
 * CronSchedule is based on UTC time. For example cron schedule "15 8 \* \* \*"
-  will run daily at 8:15am UTC.
+  will run daily at 8:15am UTC. Another example "*/2 * * * 5-6" will schedule a workflow every two minutes on fridays 
+  and saturdays.
 * If a :workflow: failed and a RetryPolicy is supplied to the StartWorkflowOptions
   as well, the :workflow: will retry based on the RetryPolicy. While the :workflow: is
   retrying, the server will not schedule the next cron run.

--- a/src/docs/05-go-client/16-distributed-cron.md
+++ b/src/docs/05-go-client/16-distributed-cron.md
@@ -16,7 +16,8 @@ You can also start a :workflow: using the Cadence :CLI: with an optional cron sc
 For :workflow:workflows: with CronSchedule:
 
 * Cron schedule is based on UTC time. For example cron schedule "15 8 \* \* \*"
-  will run daily at 8:15am UTC.
+  will run daily at 8:15am UTC. Another example "*/2 * * * 5-6" will schedule a workflow every two minutes on fridays
+  and saturdays.
 * If a :workflow: failed and a RetryPolicy is supplied to the StartWorkflowOptions
   as well, the :workflow: will retry based on the RetryPolicy. While the :workflow: is
   retrying, the server will not schedule the next cron run.


### PR DESCRIPTION
Updating with a more advanced example showing that cadence cron workflows also support "/" and "-" operators in cron scheduling.