### PR TITLE
correct output directory of prometheus.yml

### DIFF
--- a/src/docs/01-get-started/01-server-installation.md
+++ b/src/docs/01-get-started/01-server-installation.md
@@ -15,7 +15,7 @@ Follow the Docker installation instructions found here: [https://docs.docker.com
 Download the Cadence docker-compose file:
 ```bash
 
-> curl -O https://raw.githubusercontent.com/uber/cadence/master/docker/docker-compose.yml && curl -O https://raw.githubusercontent.com/uber/cadence/master/docker/prometheus/prometheus.yml
+> curl -O https://raw.githubusercontent.com/uber/cadence/master/docker/docker-compose.yml && curl --create-dirs --output-dir prometheus -O https://raw.githubusercontent.com/uber/cadence/master/docker/prometheus/prometheus.yml
 
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed


### PR DESCRIPTION
prometheus container fails to boot as it expects the prometheus.yml file in the ./prometheus directory (i.e. directory where the compose file is located):
```
prometheus:
  image: prom/prometheus:latest
  volumes:
    - ./prometheus:/etc/prometheus
  command:
    - '--config.file=/etc/prometheus/prometheus.yml'
```