### PR TITLE
fix: badges in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Cadence docs](https://cadenceworkflow.io) &middot; ![Build and Deploy](https://github.com/uber/cadence-docs/workflows/Build%20and%20Deploy/badge.svg) ![Nightly integration test](https://github.com/uber/cadence-docs/workflows/Nightly%20integration%20test/badge.svg)
+# [Cadence docs](https://cadenceworkflow.io) &middot; ![Build and Deploy](https://img.shields.io/github/actions/workflow/status/uber/Cadence-Docs/publish-to-gh-pages.yml?label=Build%20and%20Deploy&link=https%3A%2F%2Fgithub.com%2Fuber%2FCadence-Docs%2Factions%2Fworkflows%2Fpublish-to-gh-pages.yml) ![Nightly integration test](https://img.shields.io/github/actions/workflow/status/uber/Cadence-Docs/nightly-integration-test.yml?label=Nightly%20integration%20test&link=https%3A%2F%2Fgithub.com%2Fuber%2FCadence-Docs%2Factions%2Fworkflows%2Fnightly-integration-test.yml)
 
 ## Setting up for local development
 This will start a local server and can be accessed at http://localhost:8080/
@@ -7,7 +7,7 @@ This will start a local server and can be accessed at http://localhost:8080/
 
 ### Adding pages to docs
 1. Add the page under `Cadence-Docs/src/docs` in the correct place in the hierarchy
-2. Add the page to `Cadence-Docs/src/.vuepress/config.js` 
+2. Add the page to `Cadence-Docs/src/.vuepress/config.js`
 
 ## Setting up for local development for blog pages
 This will start a local server and can be accessed at http://localhost:8080/blog


### PR DESCRIPTION
When a github action workflow is disabled it disables the badge in the README.md.

I changed the source image of the badges to use shield.io 

Disabled gh workflow which triggered this issue:
https://github.com/uber/Cadence-Docs/actions/workflows/nightly-integration-test.yml

Example of issue:
<img width="901" alt="image" src="https://github.com/uber/Cadence-Docs/assets/1480657/532d4f9f-2b9e-40c4-84a8-60e742c674b8">

