### PR TITLE
Changing name of s3 bucket since dev-cad' possession is released

### DIFF
--- a/src/docs/03-concepts/07-archival.md
+++ b/src/docs/03-concepts/07-archival.md
@@ -73,10 +73,10 @@ domainDefaults:
   archival:
     history:
       status: "enabled"
-      URI: "s3://dev-cad"
+      URI: "s3://put-name-of-your-s3-bucket-here"
     visibility:
       status: "enabled"
-      URI: "s3://dev-cad"
+      URI: "s3://put-name-of-your-s3-bucket-here" # most proably the same as the previous URI
 ```
 
 ## FAQ


### PR DESCRIPTION
I believe we made this bucket while we were testing Archival feature.
It is not owned by Uber anymore, and it also may be misleading to have
the same mentioned.
