### PR TITLE
[Wf-Diagnostics] add link to troubleshooting overview page in sidebar

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -170,6 +170,7 @@ module.exports = {
           title: 'Workflow Troubleshooting',
           path: '/docs/08-workflow-troubleshooting/',
           children: [
+            '08-workflow-troubleshooting/',
             '08-workflow-troubleshooting/01-timeouts',
           ],
         },


### PR DESCRIPTION
overview page is redirected by default but would be good to also have in sidebar